### PR TITLE
Realm support

### DIFF
--- a/Code/RealmAsset.h
+++ b/Code/RealmAsset.h
@@ -1,0 +1,14 @@
+//
+//  RealmAsset.h
+//  ContentfulSDK
+//
+//  Created by Boris Bügling on 08/12/14.
+//
+//
+
+#import <ContentfulDeliveryAPI/CDAPersistedAsset.h>
+#import <Realm/RLMObject.h>
+
+@interface RealmAsset : RLMObject <CDAPersistedAsset>
+
+@end

--- a/Code/RealmAsset.m
+++ b/Code/RealmAsset.m
@@ -1,0 +1,64 @@
+//
+//  RealmAsset.m
+//  ContentfulSDK
+//
+//  Created by Boris Bügling on 08/12/14.
+//
+//
+
+#import "RealmAsset.h"
+
+@interface RealmAsset ()
+
+@property (nonatomic, assign) long realm_width;
+@property (nonatomic, assign) long realm_height;
+
+@end
+
+#pragma mark -
+
+@implementation RealmAsset
+
+@synthesize identifier;
+@synthesize internetMediaType;
+@synthesize url;
+
+#pragma mark -
+
++(NSArray*)ignoredProperties {
+    return @[ @"width", @"height" ];
+}
+
++(NSArray*)requiredProperties {
+    return @[ @"identifier", @"internetMediaType", @"url" ];
+}
+
+#pragma mark -
+
+-(NSNumber *)height {
+    return @(self.realm_height);
+}
+
+-(instancetype)init {
+    self = [super init];
+    if (self) {
+        self.identifier = @"";
+        self.internetMediaType = @"";
+        self.url = @"";
+    }
+    return self;
+}
+
+-(void)setHeight:(NSNumber *)height {
+    self.realm_height = height.longValue;
+}
+
+-(void)setWidth:(NSNumber *)width {
+    self.realm_width = width.longValue;
+}
+
+-(NSNumber *)width {
+    return @(self.realm_width);
+}
+
+@end

--- a/Code/RealmManager.h
+++ b/Code/RealmManager.h
@@ -1,0 +1,19 @@
+//
+//  RealmManager.h
+//  ContentfulSDK
+//
+//  Created by Boris Bügling on 08/12/14.
+//
+//
+
+#import <ContentfulDeliveryAPI/ContentfulDeliveryAPI.h>
+
+/**
+ A specialization of `CDAPersistenceManager` which allows you to use Realm.
+ 
+ It is not need to set a class for Assets or Spaces, this implementation will always use the same one.
+ 
+ */
+@interface RealmManager : CDAPersistenceManager
+
+@end

--- a/Code/RealmManager.m
+++ b/Code/RealmManager.m
@@ -1,0 +1,230 @@
+//
+//  RealmManager.m
+//  ContentfulSDK
+//
+//  Created by Boris Bügling on 08/12/14.
+//
+//
+
+#import <objc/runtime.h>
+#import <Realm/Realm.h>
+
+#import "CDAUtilities.h"
+#import "RealmAsset.h"
+#import "RealmManager.h"
+#import "RealmSpace.h"
+
+@interface RealmManager ()
+
+@property (nonatomic, readonly) RLMRealm* currentRealm;
+@property (nonatomic) NSMutableDictionary* relationshipsToResolve;
+
+@end
+
+#pragma mark -
+
+@implementation RealmManager
+
+-(Class)classForAssets {
+    return [RealmAsset class];
+}
+
+-(Class)classForSpaces {
+    return [RealmSpace class];
+}
+
+-(RLMRealm *)currentRealm {
+    return [RLMRealm defaultRealm];
+}
+
+-(id<CDAPersistedAsset>)createPersistedAsset {
+    id<CDAPersistedAsset> asset = [super createPersistedAsset];
+    [self.currentRealm addObject:asset];
+    return asset;
+}
+
+-(id<CDAPersistedEntry>)createPersistedEntryForContentTypeWithIdentifier:(NSString *)identifier {
+    id<CDAPersistedEntry> entry = [super createPersistedEntryForContentTypeWithIdentifier:identifier];
+
+    if (entry) {
+        [self.currentRealm addObject:entry];
+    }
+    
+    return entry;
+}
+
+-(id<CDAPersistedSpace>)createPersistedSpace {
+    id<CDAPersistedSpace> space = [super createPersistedSpace];
+    [self.currentRealm addObject:space];
+    return space;
+}
+
+-(void)deleteAssetWithIdentifier:(NSString *)identifier {
+    NSPredicate* predicate = [self predicateWithIdentifier:identifier];
+    [self.currentRealm deleteObjects:[RealmAsset objectsWithPredicate:predicate]];
+}
+
+-(void)deleteEntryWithIdentifier:(NSString *)identifier {
+    NSPredicate* predicate = [self predicateWithIdentifier:identifier];
+
+    [self forEachEntryClassDo:^(__unsafe_unretained Class entryClass) {
+        [self.currentRealm deleteObjects:[(id)entryClass objectsWithPredicate:predicate]];
+    }];
+}
+
+-(NSArray *)fetchAssetsFromDataStore {
+    NSMutableArray* assets = [@[] mutableCopy];
+    for (RealmAsset* asset in [RealmAsset allObjects]) {
+        [assets addObject:asset];
+    }
+    return [assets copy];
+}
+
+-(id<CDAPersistedAsset>)fetchAssetWithIdentifier:(NSString *)identifier {
+    return [RealmAsset objectsWithPredicate:[self predicateWithIdentifier:identifier]].firstObject;
+}
+
+-(NSArray *)fetchEntriesFromDataStore {
+    NSMutableArray* allEntries = [@[] mutableCopy];
+
+    [self forEachEntryClassDo:^(__unsafe_unretained Class entryClass) {
+        for (RLMObject* object in [(id)entryClass allObjects]) {
+            [allEntries addObject:object];
+        }
+    }];
+
+    return [allEntries copy];
+}
+
+-(id<CDAPersistedEntry>)fetchEntryWithIdentifier:(NSString *)identifier {
+    __block id<CDAPersistedEntry> result = nil;
+    NSPredicate* predicate = [self predicateWithIdentifier:identifier];
+
+    [self forEachEntryClassDo:^(__unsafe_unretained Class entryClass) {
+        RLMResults* results = [(id)entryClass objectsWithPredicate:predicate];
+        if (results.count > 0) {
+            result = results.firstObject;
+        }
+    }];
+
+    return result;
+}
+
+-(id<CDAPersistedSpace>)fetchSpaceFromDataStore {
+    return [RealmSpace allObjects].firstObject;
+}
+
+-(void)forEachEntryClassDo:(void (^)(Class entryClass))entryClassHandler {
+    NSParameterAssert(entryClassHandler);
+
+    NSMutableSet* classes = [NSMutableSet set];
+    for (NSString* identifier in self.identifiersOfHandledContentTypes) {
+        [classes addObject:[self classForEntriesOfContentTypeWithIdentifier:identifier]];
+    }
+
+    for (Class clazz in classes) {
+        entryClassHandler(clazz);
+    }
+}
+
+-(void)performSynchronizationWithSuccess:(void (^)())success failure:(CDARequestFailureBlock)failure {
+    self.relationshipsToResolve = [@{} mutableCopy];
+
+    [self.currentRealm beginWriteTransaction];
+    [super performSynchronizationWithSuccess:success failure:failure];
+}
+
+-(NSPredicate*)predicateWithIdentifier:(NSString*)identifier {
+    return [NSPredicate predicateWithFormat:@"identifier = %@", identifier];
+}
+
+-(NSArray*)relationshipsForClass:(Class)clazz {
+    unsigned int propCount = 0;
+    objc_property_t* props = class_copyPropertyList(clazz, &propCount);
+
+    NSMutableArray* relationships = [@[] mutableCopy];
+
+    for (unsigned int i = 0; i < propCount; i++) {
+        NSString* attributes = [[NSString alloc] initWithUTF8String:property_getAttributes(props[i])];
+        if ([attributes hasPrefix:@"T@"]) {
+            NSArray* attrs = [attributes componentsSeparatedByString:@"\""];
+            if (attrs.count != 3) {
+                continue;
+            }
+
+            Class propClass = NSClassFromString(attrs[1]);
+
+            if (class_getSuperclass(propClass) != RLMObject.class) {
+                continue;
+            }
+
+            [relationships addObject:[[NSString alloc] initWithUTF8String:property_getName(props[i])]];
+        }
+    }
+
+    free(props);
+    return relationships;
+}
+
+- (id)resolveResource:(CDAResource*)rsc {
+    if (CDAClassIsOfType([rsc class], CDAAsset.class)) {
+        return [self fetchAssetWithIdentifier:rsc.identifier];
+    }
+
+    if (CDAClassIsOfType([rsc class], CDAEntry.class)) {
+        return [self fetchEntryWithIdentifier:rsc.identifier];
+    }
+
+    NSAssert(false, @"Unexpectly, %@ is neither an Asset nor an Entry.", rsc);
+    return nil;
+}
+
+-(void)saveDataStore {
+    for (id<CDAPersistedEntry> entry in [self fetchEntriesFromDataStore]) {
+        NSDictionary* relationships = self.relationshipsToResolve[entry.identifier];
+
+        [relationships enumerateKeysAndObjectsUsingBlock:^(NSString* keyPath, id value, BOOL *s) {
+            value = [self resolveResource:value];
+
+            [(NSObject*)entry setValue:value forKeyPath:keyPath];
+        }];
+    }
+
+    [self.currentRealm commitWriteTransaction];
+}
+
+-(void)setClassForAssets:(Class)classForAssets {
+    NSLog(@"%@ does not need a user-provided class for Assets.", NSStringFromClass(self.class));
+}
+
+-(void)setClassForSpaces:(Class)classForSpaces {
+    NSLog(@"%@ does not need a user-provided class for Spaces.", NSStringFromClass(self.class));
+}
+
+-(void)updatePersistedEntry:(id<CDAPersistedEntry>)persistedEntry withEntry:(CDAEntry *)entry {
+    [super updatePersistedEntry:persistedEntry withEntry:entry];
+
+    Class clazz = [self classForEntriesOfContentTypeWithIdentifier:entry.contentType.identifier];
+    NSMutableDictionary* relationships = [@{} mutableCopy];
+
+    for (NSString* relationshipName in [self relationshipsForClass:clazz]) {
+        NSDictionary* mappingForEntries = [super mappingForEntriesOfContentTypeWithIdentifier:entry.contentType.identifier];
+        NSString* entryKeyPath = [[mappingForEntries allKeysForObject:relationshipName] firstObject];
+
+        if (!entryKeyPath) {
+            return;
+        }
+
+        id relationshipTarget = [entry valueForKeyPath:entryKeyPath];
+
+        if (!relationshipTarget) {
+            return;
+        }
+
+        relationships[relationshipName] = relationshipTarget;
+    }
+
+    self.relationshipsToResolve[entry.identifier] = [relationships copy];
+}
+
+@end

--- a/Code/RealmSpace.h
+++ b/Code/RealmSpace.h
@@ -1,0 +1,14 @@
+//
+//  RealmSpace.h
+//  ContentfulSDK
+//
+//  Created by Boris Bügling on 08/12/14.
+//
+//
+
+#import <ContentfulDeliveryAPI/CDAPersistedSpace.h>
+#import <Realm/RLMObject.h>
+
+@interface RealmSpace : RLMObject <CDAPersistedSpace>
+
+@end

--- a/Code/RealmSpace.m
+++ b/Code/RealmSpace.m
@@ -1,0 +1,33 @@
+//
+//  RealmSpace.m
+//  ContentfulSDK
+//
+//  Created by Boris Bügling on 08/12/14.
+//
+//
+
+#import "RealmSpace.h"
+
+@implementation RealmSpace
+
+@synthesize lastSyncTimestamp;
+@synthesize syncToken;
+
+#pragma mark -
+
++(NSArray*)requiredProperties {
+    return @[ @"lastSyncTimestamp", @"syncToken" ];
+}
+
+#pragma mark -
+
+-(instancetype)init {
+    self = [super init];
+    if (self) {
+        self.lastSyncTimestamp = [NSDate dateWithTimeIntervalSince1970:0];
+        self.syncToken = @"";
+    }
+    return self;
+}
+
+@end

--- a/ContentfulPersistence.podspec
+++ b/ContentfulPersistence.podspec
@@ -10,16 +10,26 @@ Pod::Spec.new do |s|
   s.social_media_url = 'https://twitter.com/contentful'
 
   s.requires_arc  = true
-  s.frameworks    = 'CoreData'
 
-  s.source_files        = 'Code'
-  s.public_header_files = 'Code/*.h'
-
-  s.ios.deployment_target     = '6.0'
-  s.ios.source_files          = 'Code/UIKit'
-  s.ios.public_header_files   = 'Code/UIKit/*.h'
-
-  s.osx.deployment_target     = '10.8'
+  s.ios.deployment_target = '6.0'
+  s.osx.deployment_target = '10.8'
 
   s.dependency 'ContentfulDeliveryAPI', '~> 1.9.4'
+
+  s.default_subspecs = 'CoreData'
+
+  s.subspec 'CoreData' do |ss|
+    ss.frameworks         = 'CoreData'
+    ss.source_files       = 'Code/CoreData*.{h,m}'
+    ss.ios.source_files   = 'Code/UIKit'
+  end
+
+  s.subspec 'Realm' do |ss|
+    ss.dependency 'Realm', '~> 0.98.0'
+
+    ss.source_files = 'Code/Realm*.{h,m}'
+
+    ss.ios.deployment_target   = '7.0'
+    ss.osx.deployment_target   = '10.9'
+  end
 end


### PR DESCRIPTION
This adds a new, non-default subspec "Realm" which will provide support for using Realm to persist Contentful data. It is based on the older example for Realm support from [contentful.objc](https://github.com/contentful/contentful.objc).

Enhancements:
- Supports the latest version of Realm (0.98.2)
- Fixes issue with indirect descendants of `RLMObject`
- Implements support for to-many relationships.

Fixes contentful/contentful.objc#50
Fixes contentful/contentful.objc#22
